### PR TITLE
scanref依赖扫描

### DIFF
--- a/app/src/main/java/com/dodola/rocoosample/HelloHack.java
+++ b/app/src/main/java/com/dodola/rocoosample/HelloHack.java
@@ -3,16 +3,12 @@
  */
 package com.dodola.rocoosample;
 
-import com.dodola.rocoosample.Ref.RefByHelloHack;
-
 /**
  * Created by sunpengfei on 16/5/24.
  */
 public class HelloHack {
 
     public String showHello() {
-        RefByHelloHack a = new RefByHelloHack();
-        a.toString();
-        return "==============H";
+        return "===============H";
     }
 }

--- a/app/src/main/java/com/dodola/rocoosample/HelloHack.java
+++ b/app/src/main/java/com/dodola/rocoosample/HelloHack.java
@@ -3,12 +3,16 @@
  */
 package com.dodola.rocoosample;
 
+import com.dodola.rocoosample.Ref.RefByHelloHack;
+
 /**
  * Created by sunpengfei on 16/5/24.
  */
 public class HelloHack {
 
     public String showHello() {
-        return "H";
+        RefByHelloHack a = new RefByHelloHack();
+        a.toString();
+        return "==============H";
     }
 }

--- a/app/src/main/java/com/dodola/rocoosample/MainActivity.java
+++ b/app/src/main/java/com/dodola/rocoosample/MainActivity.java
@@ -9,6 +9,7 @@ import android.view.View;
 import android.widget.Toast;
 
 import com.dodola.rocoofix.RocooFix;
+import com.dodola.rocoosample.Ref.RefByHelloHack;
 
 
 public class MainActivity extends AppCompatActivity {
@@ -21,6 +22,8 @@ public class MainActivity extends AppCompatActivity {
             @Override
             public void onClick(View v) {
                 HelloHack hack = new HelloHack();
+                RefByHelloHack aaa=new RefByHelloHack();
+                Toast.makeText(MainActivity.this, aaa.showHello(), Toast.LENGTH_SHORT).show();
                 Toast.makeText(MainActivity.this, hack.showHello(), Toast.LENGTH_SHORT).show();
             }
         });

--- a/app/src/main/java/com/dodola/rocoosample/Ref/RefByHelloHack.java
+++ b/app/src/main/java/com/dodola/rocoosample/Ref/RefByHelloHack.java
@@ -1,0 +1,8 @@
+package com.dodola.rocoosample.Ref;
+
+/**
+ * 测试依赖关系
+ * Created by shoyu666 on 16/7/15.
+ */
+public class RefByHelloHack {
+}

--- a/app/src/main/java/com/dodola/rocoosample/Ref/RefByHelloHack.java
+++ b/app/src/main/java/com/dodola/rocoosample/Ref/RefByHelloHack.java
@@ -1,8 +1,19 @@
 package com.dodola.rocoosample.Ref;
 
+import com.dodola.rocoosample.HelloHack;
+
 /**
  * 测试依赖关系
+ * 测试修改HelloHack 会导致RefByHelloHack加入补丁
  * Created by shoyu666 on 16/7/15.
  */
 public class RefByHelloHack {
+    public String showHello() {
+        HelloHack a = new HelloHack();
+        a.toString();
+        return "==============H";
+    }
+    public String test() {
+        return "YYYYYYYYYYYYY";
+    }
 }

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ArchivePathElement.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ArchivePathElement.java
@@ -1,0 +1,70 @@
+package com.dodola.rocoofix.ref;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+class ArchivePathElement implements ClassPathElement {
+    static class DirectoryEntryException extends IOException {
+    }
+    private final ZipFile archive;
+    public ArchivePathElement(ZipFile archive) {
+        this.archive = archive;
+    }
+    @Override
+    public InputStream open(String path) throws IOException {
+        ZipEntry entry = archive.getEntry(path);
+        if (entry == null) {
+            throw new FileNotFoundException("File \"" + path + "\" not found");
+        } else if (entry.isDirectory()) {
+            throw new DirectoryEntryException();
+        } else {
+            return archive.getInputStream(entry);
+        }
+    }
+    @Override
+    public void close() throws IOException {
+        archive.close();
+    }
+    @Override
+    public Iterable<String> list() {
+        return new Iterable<String>() {
+            @Override
+            public Iterator<String> iterator() {
+                return new Iterator<String>() {
+                    Enumeration<? extends ZipEntry> delegate = archive.entries();
+                    ZipEntry next = null;
+                    @Override
+                    public boolean hasNext() {
+                        while (next == null && delegate.hasMoreElements()) {
+                            next = delegate.nextElement();
+                            if (next.isDirectory()) {
+                                next = null;
+                            }
+                        }
+                        return next != null;
+                    }
+                    @Override
+                    public String next() {
+                        if (hasNext()) {
+                            String name = next.getName();
+                            next = null;
+                            return name;
+                        } else {
+                            throw new NoSuchElementException();
+                        }
+                    }
+                    @Override
+                    public void remove() {
+                        throw new UnsupportedOperationException();
+                    }
+                };
+            }
+        };
+    }
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassPathElement.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassPathElement.java
@@ -1,0 +1,17 @@
+package com.dodola.rocoofix.ref;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+interface ClassPathElement {
+    char SEPARATOR_CHAR = '/';
+    /**
+     * Open a "file" from this {@code ClassPathElement}.
+     * @param path a '/' separated relative path to the wanted file.
+     * @return an {@code InputStream} ready to read the requested file.
+     * @throws IOException if the path can not be found or if an error occurred while opening it.
+     */
+    InputStream open(String path) throws IOException;
+    void close() throws IOException;
+    Iterable<String> list();
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassReferenceListBuilder.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassReferenceListBuilder.java
@@ -1,0 +1,155 @@
+package com.dodola.rocoofix.ref;
+
+import com.android.dx.cf.direct.DirectClassFile;
+import com.android.dx.cf.iface.FieldList;
+import com.android.dx.cf.iface.MethodList;
+import com.android.dx.rop.cst.Constant;
+import com.android.dx.rop.cst.CstBaseMethodRef;
+import com.android.dx.rop.cst.CstFieldRef;
+import com.android.dx.rop.cst.CstType;
+import com.android.dx.rop.type.Prototype;
+import com.android.dx.rop.type.StdTypeList;
+import com.android.dx.rop.type.TypeList;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Tool to find direct class references to other classes.
+ */
+public class ClassReferenceListBuilder {
+    private static final String CLASS_EXTENSION = ".class";
+    private final Path path;
+    private final Set<String> classNames = new HashSet<String>();
+
+    public ClassReferenceListBuilder(Path path) {
+        this.path = path;
+    }
+    /**
+     * Kept for compatibility with the gradle integration, this method just forwards to
+     * {@link MainDexListBuilder#main(String[])}.
+     * @deprecated use {@link MainDexListBuilder#main(String[])} instead.
+     */
+    @Deprecated
+    public static void main(String[] args) {
+        MainDexListBuilder.main(args);
+    }
+    /**
+     * @param jarOfRoots Archive containing the class files resulting of the tracing, typically
+     * this is the result of running ProGuard.
+     */
+    public void addRoots(ZipFile jarOfRoots) throws IOException {
+        // keep roots
+        for (Enumeration<? extends ZipEntry> entries = jarOfRoots.entries();
+                entries.hasMoreElements();) {
+            ZipEntry entry = entries.nextElement();
+            String name = entry.getName();
+            if (name.endsWith(CLASS_EXTENSION)) {
+                classNames.add(name.substring(0, name.length() - CLASS_EXTENSION.length()));
+            }
+        }
+        // keep direct references of roots (+ direct references hierarchy)
+        for (Enumeration<? extends ZipEntry> entries = jarOfRoots.entries();
+                entries.hasMoreElements();) {
+            ZipEntry entry = entries.nextElement();
+            String name = entry.getName();
+            if (name.endsWith(CLASS_EXTENSION)) {
+                DirectClassFile classFile;
+                try {
+                    classFile = path.getClass(name);
+                    addDependencies(classFile);
+                } catch (FileNotFoundException e) {
+
+                }
+
+            }
+        }
+    }
+
+
+    public void addRootsV2(String name){
+        if (name.endsWith(CLASS_EXTENSION)) {
+            classNames.add(name.substring(0, name.length() - CLASS_EXTENSION.length()));
+        }
+        if (name.endsWith(CLASS_EXTENSION)) {
+            DirectClassFile classFile;
+            try {
+                classFile = path.getClass(name);
+                addDependencies(classFile);
+            } catch (FileNotFoundException e) {
+//                throw new IOException("Class " + name +
+//                        " is missing form original class path " + path, e);
+            }
+
+        }
+    }
+   public Set<String> getClassNames() {
+        return classNames;
+    }
+    private void addDependencies(DirectClassFile classFile) {
+        for (Constant constant : classFile.getConstantPool().getEntries()) {
+            if (constant instanceof CstType) {
+                checkDescriptor(((CstType) constant).getClassType().getDescriptor());
+            } else if (constant instanceof CstFieldRef) {
+                checkDescriptor(((CstFieldRef) constant).getType().getDescriptor());
+            } else if (constant instanceof CstBaseMethodRef) {
+                checkPrototype(((CstBaseMethodRef) constant).getPrototype());
+            }
+        }
+        FieldList fields = classFile.getFields();
+        int nbField = fields.size();
+        for (int i = 0; i < nbField; i++) {
+          checkDescriptor(fields.get(i).getDescriptor().getString());
+        }
+        MethodList methods = classFile.getMethods();
+        int nbMethods = methods.size();
+        for (int i = 0; i < nbMethods; i++) {
+          checkPrototype(Prototype.intern(methods.get(i).getDescriptor().getString()));
+        }
+    }
+    private void checkPrototype(Prototype proto) {
+      checkDescriptor(proto.getReturnType().getDescriptor());
+      StdTypeList args = proto.getParameterTypes();
+      for (int i = 0; i < args.size(); i++) {
+          checkDescriptor(args.get(i).getDescriptor());
+      }
+    }
+    private void checkDescriptor(String typeDescriptor) {
+        if (typeDescriptor.endsWith(";")) {
+            int lastBrace = typeDescriptor.lastIndexOf('[');
+            if (lastBrace < 0) {
+                addClassWithHierachy(typeDescriptor.substring(1, typeDescriptor.length()-1));
+            } else {
+                assert typeDescriptor.length() > lastBrace + 3
+                && typeDescriptor.charAt(lastBrace + 1) == 'L';
+                addClassWithHierachy(typeDescriptor.substring(lastBrace + 2,
+                        typeDescriptor.length() - 1));
+            }
+        }
+    }
+    private void addClassWithHierachy(String classBinaryName) {
+        if (classNames.contains(classBinaryName)) {
+            return;
+        }
+        try {
+            DirectClassFile classFile = path.getClass(classBinaryName + CLASS_EXTENSION);
+            classNames.add(classBinaryName);
+            CstType superClass = classFile.getSuperclass();
+            if (superClass != null) {
+                addClassWithHierachy(superClass.getClassType().getClassName());
+            }
+            TypeList interfaceList = classFile.getInterfaces();
+            int interfaceNumber = interfaceList.size();
+            for (int i = 0; i < interfaceNumber; i++) {
+                addClassWithHierachy(interfaceList.getType(i).getClassName());
+            }
+        } catch (FileNotFoundException e) {
+            // Ignore: The referenced type is not in the path it must be part of the libraries.
+        }
+    }
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassReferenceListBuilder.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/ClassReferenceListBuilder.java
@@ -27,6 +27,10 @@ public class ClassReferenceListBuilder {
     private final Path path;
     private final Set<String> classNames = new HashSet<String>();
 
+    public  void clearAllForReuse(){
+        classNames.clear();
+    }
+
     public ClassReferenceListBuilder(Path path) {
         this.path = path;
     }

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/FolderPathElement.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/FolderPathElement.java
@@ -1,0 +1,55 @@
+
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.dodola.rocoofix.ref;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.ArrayList;
+
+/**
+ * A folder element.
+ */
+class FolderPathElement implements ClassPathElement {
+    private File baseFolder;
+    public FolderPathElement(File baseFolder) {
+        this.baseFolder = baseFolder;
+    }
+    @Override
+    public InputStream open(String path) throws FileNotFoundException {
+        return new FileInputStream(new File(baseFolder,
+                path.replace(SEPARATOR_CHAR, File.separatorChar)));
+    }
+    @Override
+    public void close() {
+    }
+    @Override
+    public Iterable<String> list() {
+        ArrayList<String> result = new ArrayList<String>();
+        collect(baseFolder, "", result);
+        return result;
+    }
+    private void collect(File folder, String prefix, ArrayList<String> result) {
+        for (File file : folder.listFiles()) {
+            if (file.isDirectory()) {
+                collect(file, prefix + SEPARATOR_CHAR + file.getName(), result);
+            } else {
+                result.add(prefix + SEPARATOR_CHAR + file.getName());
+            }
+        }
+    }
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/MainDexListBuilder.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/MainDexListBuilder.java
@@ -1,0 +1,164 @@
+package com.dodola.rocoofix.ref;
+
+import com.android.dx.cf.attrib.AttRuntimeVisibleAnnotations;
+import com.android.dx.cf.direct.DirectClassFile;
+import com.android.dx.cf.iface.Attribute;
+import com.android.dx.cf.iface.FieldList;
+import com.android.dx.cf.iface.HasAttribute;
+import com.android.dx.cf.iface.MethodList;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipFile;
+
+/**
+ * This is a command line tool used by mainDexClasses script to build a main dex classes list. First
+ * argument of the command line is an archive, each class file contained in this archive is used to
+ * identify a class that can be used during secondary dex installation, those class files
+ * are not opened by this tool only their names matter. Other arguments must be zip files or
+ * directories, they constitute in a classpath in with the classes named by the first argument
+ * will be searched. Each searched class must be found. On each of this classes are searched for
+ * their dependencies to other classes. The tool also browses for classes annotated by runtime
+ * visible annotations and adds them to the list/ Finally the tools prints on standard output a list
+ * of class files names suitable as content of the file argument --main-dex-list of dx.
+ */
+public class MainDexListBuilder {
+    private static final String CLASS_EXTENSION = ".class";
+    private static final int STATUS_ERROR = 1;
+    private static final String EOL = System.getProperty("line.separator");
+    private static String USAGE_MESSAGE =
+            "Usage:" + EOL + EOL +
+            "Short version: Don't use this." + EOL + EOL +
+            "Slightly longer version: This tool is used by mainDexClasses script to build" + EOL +
+            "the main dex list." + EOL;
+    /**
+     * By default we force all classes annotated with runtime annotation to be kept in the
+     * main dex list. This option disable the workaround, limiting the index pressure in the main
+     * dex but exposing to the Dalvik resolution bug. The resolution bug occurs when accessing
+     * annotations of a class that is not in the main dex and one of the annotations as an enum
+     * parameter.
+     *
+     * @see <a href="https://code.google.com/p/android/issues/detail?id=78144">bug discussion</a>
+     *
+     */
+    private static final String DISABLE_ANNOTATION_RESOLUTION_WORKAROUND =
+            "--disable-annotation-resolution-workaround";
+    private Set<String> filesToKeep = new HashSet<String>();
+    public static void main(String[] args) {
+        int argIndex = 0;
+        boolean keepAnnotated = true;
+        while (argIndex < args.length -2) {
+            if (args[argIndex].equals(DISABLE_ANNOTATION_RESOLUTION_WORKAROUND)) {
+                keepAnnotated = false;
+            } else {
+                System.err.println("Invalid option " + args[argIndex]);
+                printUsage();
+                System.exit(STATUS_ERROR);
+            }
+            argIndex++;
+        }
+        if (args.length - argIndex != 2) {
+            printUsage();
+            System.exit(STATUS_ERROR);
+        }
+        try {
+            MainDexListBuilder builder = new MainDexListBuilder(keepAnnotated, args[argIndex],
+                    args[argIndex + 1]);
+            Set<String> toKeep = builder.getMainDexList();
+            printList(toKeep);
+        } catch (IOException e) {
+            System.err.println("A fatal error occured: " + e.getMessage());
+            System.exit(STATUS_ERROR);
+            return;
+        }
+    }
+    public MainDexListBuilder(boolean keepAnnotated, String rootJar, String pathString)
+            throws IOException {
+        ZipFile jarOfRoots = null;
+        Path path = null;
+        try {
+            try {
+                jarOfRoots = new ZipFile(rootJar);
+            } catch (IOException e) {
+                throw new IOException("\"" + rootJar + "\" can not be read as a zip archive. ("
+                        + e.getMessage() + ")", e);
+            }
+            path = new Path(pathString);
+            ClassReferenceListBuilder mainListBuilder = new ClassReferenceListBuilder(path);
+            mainListBuilder.addRoots(jarOfRoots);
+            for (String className : mainListBuilder.getClassNames()) {
+                filesToKeep.add(className + CLASS_EXTENSION);
+            }
+            if (keepAnnotated) {
+                keepAnnotated(path);
+            }
+        } finally {
+            try {
+                jarOfRoots.close();
+            } catch (IOException e) {
+                // ignore
+            }
+            if (path != null) {
+                for (ClassPathElement element : path.elements) {
+                    try {
+                        element.close();
+                    } catch (IOException e) {
+                        // keep going, lets do our best.
+                    }
+                }
+            }
+        }
+    }
+    /**
+     * Returns a list of classes to keep. This can be passed to dx as a file with --main-dex-list.
+     */
+    public Set<String> getMainDexList() {
+        return filesToKeep;
+    }
+    private static void printUsage() {
+        System.err.print(USAGE_MESSAGE);
+    }
+    private static void printList(Set<String> fileNames) {
+        for (String fileName : fileNames) {
+            System.out.println(fileName);
+        }
+    }
+    /**
+     * Keep classes annotated with runtime annotations.
+     */
+    private void keepAnnotated(Path path) throws FileNotFoundException {
+        for (ClassPathElement element : path.getElements()) {
+            forClazz:
+                for (String name : element.list()) {
+                    if (name.endsWith(CLASS_EXTENSION)) {
+                        DirectClassFile clazz = path.getClass(name);
+                        if (hasRuntimeVisibleAnnotation(clazz)) {
+                            filesToKeep.add(name);
+                        } else {
+                            MethodList methods = clazz.getMethods();
+                            for (int i = 0; i<methods.size(); i++) {
+                                if (hasRuntimeVisibleAnnotation(methods.get(i))) {
+                                    filesToKeep.add(name);
+                                    continue forClazz;
+                                }
+                            }
+                            FieldList fields = clazz.getFields();
+                            for (int i = 0; i<fields.size(); i++) {
+                                if (hasRuntimeVisibleAnnotation(fields.get(i))) {
+                                    filesToKeep.add(name);
+                                    continue forClazz;
+                                }
+                            }
+                        }
+                    }
+                }
+        }
+    }
+    private boolean hasRuntimeVisibleAnnotation(HasAttribute element) {
+        Attribute att = element.getAttributes().findFirst(
+                AttRuntimeVisibleAnnotations.ATTRIBUTE_NAME);
+        return (att != null && ((AttRuntimeVisibleAnnotations)att).getAnnotations().size()>0);
+    }
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/PatchRefScan.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/PatchRefScan.java
@@ -34,7 +34,7 @@ public class PatchRefScan {
     }
     public static void addClasstoPatch(JarEntry jarEntry,String className,JarFile alljar,File patchDir) throws Exception{
         System.out.println("============addClasstoPatch======"+className);
-        File entryFile = new File("${patchDir}/${className}");
+        File entryFile = new File(patchDir,className);
         if(!entryFile.exists()){
             InputStream inputStreamX = alljar.getInputStream(jarEntry);
             byte[] bytes = NuwaProcessor.referHackWhenInit(inputStreamX);

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/PatchRefScan.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/PatchRefScan.java
@@ -1,0 +1,44 @@
+package com.dodola.rocoofix.ref;
+
+import com.dodola.rocoofix.utils.NuwaProcessor;
+
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+
+/**
+ * Created by shoyu666 on 16/7/16.
+ */
+public class PatchRefScan {
+
+    /**
+     *  判断className是否调用了补丁,如果是加入补丁
+     * @param className jar包中的一个类
+     * @param allref    className类的依赖
+     * @param patchClasses  补丁类
+     */
+    public static void addClassIfRefPatchClass(JarEntry jarEntry, String className, Set<String> allref, Set<String> patchClasses, JarFile alljar, File patchDir) throws Exception{
+        for(String ref:allref){
+            if(patchClasses.contains(ref+".class")){
+                //该类如果引用了补丁
+                addClasstoPatch(jarEntry,className,alljar,patchDir);
+                break;
+            }
+        }
+    }
+    public static void addClasstoPatch(JarEntry jarEntry,String className,JarFile alljar,File patchDir) throws Exception{
+        System.out.println("============addClasstoPatch======"+className);
+        File entryFile = new File("${patchDir}/${className}");
+        if(!entryFile.exists()){
+            InputStream inputStreamX = alljar.getInputStream(jarEntry);
+            byte[] bytes = NuwaProcessor.referHackWhenInit(inputStreamX);
+            FileUtils.writeByteArrayToFile(entryFile, bytes);
+        }
+    }
+}

--- a/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/Path.java
+++ b/buildsrc/src/main/groovy/com/dodola/rocoofix/ref/Path.java
@@ -1,0 +1,95 @@
+package com.dodola.rocoofix.ref;
+
+import com.android.dx.cf.direct.DirectClassFile;
+import com.android.dx.cf.direct.StdAttributeFactory;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.zip.ZipException;
+import java.util.zip.ZipFile;
+
+class Path {
+    static ClassPathElement getClassPathElement(File file)
+            throws ZipException, IOException {
+        if (file.isDirectory()) {
+            return new FolderPathElement(file);
+        } else if (file.isFile()) {
+            return new ArchivePathElement(new ZipFile(file));
+        } else if (file.exists()) {
+            throw new IOException("\"" + file.getPath() +
+                    "\" is not a directory neither a zip file");
+        } else {
+            throw new FileNotFoundException("File \"" + file.getPath() + "\" not found");
+        }
+    }
+    List<ClassPathElement> elements = new ArrayList<ClassPathElement>();
+    private final String definition;
+    private final ByteArrayOutputStream baos = new ByteArrayOutputStream(40 * 1024);
+    private final byte[] readBuffer = new byte[20 * 1024];
+    public Path(String definition) {
+        this.definition = definition;
+        for (String filePath : definition.split(Pattern.quote(File.pathSeparator))) {
+            try {
+                addElement(getClassPathElement(new File(filePath)));
+            } catch (IOException e) {
+                //throw new IOException("Wrong classpath: " + e.getMessage(), e);
+                e.printStackTrace();
+            }
+        }
+    }
+    private static byte[] readStream(InputStream in, ByteArrayOutputStream baos, byte[] readBuffer)
+            throws IOException {
+        try {
+            for (;;) {
+                int amt = in.read(readBuffer);
+                if (amt < 0) {
+                    break;
+                }
+                baos.write(readBuffer, 0, amt);
+            }
+        } finally {
+            in.close();
+        }
+        return baos.toByteArray();
+    }
+    @Override
+    public String toString() {
+        return definition;
+    }
+    Iterable<ClassPathElement> getElements() {
+      return elements;
+    }
+    private void addElement(ClassPathElement element) {
+        assert element != null;
+        elements.add(element);
+    }
+    synchronized DirectClassFile getClass(String path) throws FileNotFoundException {
+        DirectClassFile classFile = null;
+        for (ClassPathElement element : elements) {
+            try {
+                InputStream in = element.open(path);
+                try {
+                    byte[] bytes = readStream(in, baos, readBuffer);
+                    baos.reset();
+                    classFile = new DirectClassFile(bytes, path, false);
+                    classFile.setAttributeFactory(StdAttributeFactory.THE_ONE);
+                    break;
+                } finally {
+                    in.close();
+                }
+            } catch (IOException e) {
+                // search next element
+            }
+        }
+        if (classFile == null) {
+            throw new FileNotFoundException("File \"" + path + "\" not found");
+        }
+        return classFile;
+    }
+}


### PR DESCRIPTION
上一个pr的问题忽略了调用补丁类的所有类，只是把补丁类的依赖加入
1：扫描补丁类的依赖（主要是为了拿到继承）
2：扫描一次整个jar包，找到所以调用了补丁里面的类的类
3：每次找的类写入前判断是否已经存在，已经存在无需再加入
