### PR TITLE
modify package name in AndroidManifest.xml

### DIFF
--- a/rocoo/src/main/AndroidManifest.xml
+++ b/rocoo/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
   ~ Copyright (C) 2016 Baidu, Inc. All Rights Reserved.
   -->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.dodola.rocoo">
+    package="com.dodola.rocoofix">
 
     <application android:allowBackup="true"
         android:label="@string/app_name"


### PR DESCRIPTION
修改AndroidManifest.xml中的包名, 否则打出的maven包中BuildConfig不在项目包中.

![](https://github.com/qbeenslee/ART/blob/master/other/rocoofix-manifest.png?raw=true)